### PR TITLE
Update example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,11 @@ This explicit record creation can be done any time you have a record in your rou
 
 ```purescript
   { ...
-  , "Feed": path "feed" $ params { search: optional }
+  , "Feed": path "feed" $ params { search: optional <<< string }
   -- alternately
-  , "Feed": "feed" / params { search: optional }
+  , "Feed": "feed" / params { search: optional <<< string }
   -- alternately
-  , "Feed": "feed" ? { search: optional }
+  , "Feed": "feed" ? { search: optional <<< string }
   }
 ```
 
@@ -221,7 +221,7 @@ route = root $ sum
   { "Root": noArgs
   , "Profile": "user" / segment
   , "Post": "user" / segment / "post" / int segment
-  , "Feed": "feed" ? { search: optional }
+  , "Feed": "feed" ? { search: optional <<< string }
   }
 ```
 


### PR DESCRIPTION
This did not compile without the `<<< string`:

```
  No type class instance was found for
  
    Prim.RowList.RowToList ( search :: forall a b. RouteDuplex a b -> RouteDuplex ... ...
                           )
                           t2
  
  The instance head contains unknown type variables. Consider adding a type annotation.
```

The more verbose one `(record # _search := optional (param "search"))` worked though.